### PR TITLE
Add IconAssets loader

### DIFF
--- a/src/assets/icon_assets.rs
+++ b/src/assets/icon_assets.rs
@@ -1,0 +1,33 @@
+use bevy::asset::UntypedHandle;
+use bevy::prelude::*;
+use bevy_asset_loader::prelude::AssetCollection;
+use std::collections::HashMap;
+
+#[derive(Resource)]
+pub struct IconAssets(pub HashMap<String, Handle<Image>>);
+
+impl AssetCollection for IconAssets {
+    fn create(world: &mut World) -> Self {
+        let asset_server = world
+            .get_resource::<AssetServer>()
+            .expect("AssetServer missing");
+        let mut map = HashMap::new();
+        if let Ok(handles) = asset_server.load_folder("icons") {
+            for handle in handles {
+                if let Some(path) = asset_server.get_handle_path(&handle) {
+                    if let Some(stem) = path.path().file_stem().and_then(|s| s.to_str()) {
+                        map.insert(stem.to_string(), handle.clone().typed());
+                    }
+                }
+            }
+        }
+        IconAssets(map)
+    }
+
+    fn load(world: &mut World) -> Vec<UntypedHandle> {
+        let asset_server = world
+            .get_resource::<AssetServer>()
+            .expect("AssetServer missing");
+        asset_server.load_folder("icons").unwrap_or_default()
+    }
+}

--- a/src/assets/mod.rs
+++ b/src/assets/mod.rs
@@ -1,4 +1,6 @@
 // src/assets/mod.rs
 mod fonts;
+mod icon_assets;
 pub use fonts::FontAssets;
+pub use icon_assets::IconAssets;
 pub mod icons;

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -3,7 +3,7 @@ use bevy::prelude::*;
 use bevy_asset_loader::prelude::*;
 use bevy_common_assets::ron::RonAssetPlugin;
 
-use crate::assets::{icons::resource::*, FontAssets};
+use crate::assets::{icons::resource::*, FontAssets, IconAssets};
 use crate::camera::CameraPlugin;
 use crate::components::helper::*;
 use crate::components::{
@@ -72,7 +72,8 @@ impl Plugin for ForgeUiPlugin {
             .add_loading_state(
                 LoadingState::new(UiState::LoadingAssets)
                     .continue_to_state(UiState::LoadingTheme)
-                    .load_collection::<FontAssets>(),
+                    .load_collection::<FontAssets>()
+                    .load_collection::<IconAssets>(),
             )
             // endregion
             // region: 3) Register RON asset type


### PR DESCRIPTION
## Summary
- load icons from `assets/icons` with an IconAssets resource
- expose IconAssets from the assets module
- load IconAssets in `ForgeUiPlugin`

## Testing
- `cargo fmt --all`
- `cargo check` *(fails: The system library `alsa` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848214f44d0832eab75936ce0981f43