### PR TITLE
Update docs for icon assets

### DIFF
--- a/src/assets/icon_assets.rs
+++ b/src/assets/icon_assets.rs
@@ -1,3 +1,25 @@
+//! Collection of icon textures loaded at startup.
+//!
+//! All files inside the `assets/icons` directory are loaded via
+//! [`bevy_asset_loader`](https://github.com/NiklasEi/bevy_asset_loader) and
+//! stored in a simple `HashMap`. Builders which support icons receive a
+//! [`Res<IconAssets>`](IconAssets) parameter so they can fetch handles by name:
+//!
+//! ```rust
+//! use forge_ui::prelude::*;
+//!
+//! fn ui_system(mut commands: Commands, theme: Res<UiTheme>, icons: Res<IconAssets>) {
+//!     let check = icons.0.get("check").expect("missing 'check' icon").clone();
+//!     commands.spawn(NodeBundle::default()).with_children(|parent| {
+//!         BadgeBuilder::new("Checked")
+//!             .leading_icon(check)
+//!             .spawn(parent, &theme, &theme.font.family.default);
+//!     });
+//! }
+//! ```
+//!
+//! See the showcase modules for more examples.
+
 use bevy::asset::UntypedHandle;
 use bevy::prelude::*;
 use bevy_asset_loader::prelude::AssetCollection;

--- a/src/assets/icons/mod.rs
+++ b/src/assets/icons/mod.rs
@@ -1,4 +1,6 @@
-//! Deprecated icon building utilities.
+//! Helper module for icon assets.
 //!
-//! Icons are now loaded via [`IconAssets`](crate::assets::IconAssets).
+//! All icon textures live in the `assets/icons` directory and are loaded into
+//! [`IconAssets`](crate::assets::IconAssets) at startup. Builders expecting
+//! icons take a reference to this resource so handles can be fetched by name.
 

--- a/src/assets/mod.rs
+++ b/src/assets/mod.rs
@@ -1,4 +1,19 @@
-// src/assets/mod.rs
+//! Asset collections used by Forge UI.
+//!
+//! The [`ForgeUiPlugin`](crate::plugin::ForgeUiPlugin) loads both fonts and
+//! icons at startup using `bevy_asset_loader`. Icons can then be accessed via
+//! [`IconAssets`], e.g. `icons.0.get("check")`.
+//!
+//! ```rust
+//! use forge_ui::prelude::*;
+//!
+//! fn system(icons: Res<IconAssets>) {
+//!     if let Some(handle) = icons.0.get("cross_1") {
+//!         // use `handle` with a builder
+//!     }
+//! }
+//! ```
+//
 mod fonts;
 mod icon_assets;
 pub use fonts::FontAssets;

--- a/src/components/badge/builder.rs
+++ b/src/components/badge/builder.rs
@@ -29,6 +29,7 @@ use crate::theme::UiTheme;
 ///     mut commands: Commands,
 ///     theme: Res<UiTheme>,
 ///     asset_server: Res<AssetServer>,
+///     icons: Res<IconAssets>,
 /// ) {
 ///     commands.spawn(NodeBundle::default()).with_children(|parent| {
 ///         let font: Handle<Font> = asset_server.load("fonts/Roboto-Regular.ttf");
@@ -38,7 +39,11 @@ use crate::theme::UiTheme;
 ///             .spawn(parent, &theme, &font);
 ///
 ///         // Sekundäre Variante mit Icons
-///         let star_icon: Handle<Image> = asset_server.load("icons/star.png");
+///         let star_icon = icons
+///             .0
+///             .get("star")
+///             .expect("missing 'star' icon")
+///             .clone();
 ///         BadgeBuilder::new("Favorit")
 ///             .variant(BadgeVariant::Secondary)
 ///             .leading_icon(star_icon.clone())


### PR DESCRIPTION
## Summary
- document icon asset usage in `IconAssets` and `assets` module
- remove outdated note about deprecated icon builder
- update `BadgeBuilder` example to use `IconAssets`

## Testing
- `cargo check` *(fails: alsa-sys build script requires system library)*

------
https://chatgpt.com/codex/tasks/task_e_684827bb54c4832ea6d6650a62636871