### PR TITLE
Support loading icons at multiple resolutions

### DIFF
--- a/src/assets/icon_assets.rs
+++ b/src/assets/icon_assets.rs
@@ -1,8 +1,9 @@
 //! Collection of icon textures loaded at startup.
 //!
-//! All files inside the `assets/icons` directory are loaded via
+//! Icons are provided in multiple resolutions inside the `assets/16x16`,
+//! `assets/32x32` and `assets/64x64` folders. All files are loaded via
 //! [`bevy_asset_loader`](https://github.com/NiklasEi/bevy_asset_loader) and
-//! stored in a simple `HashMap`. Builders which support icons receive a
+//! stored in simple `HashMap`s. Builders which support icons receive a
 //! [`Res<IconAssets>`](IconAssets) parameter so they can fetch handles by name:
 //!
 //! ```rust
@@ -19,6 +20,11 @@
 //! ```
 //!
 //! See the showcase modules for more examples.
+//!
+//! The tuple fields correspond to the three icon resolutions:
+//! * `icons.0` – 16&times;16
+//! * `icons.1` – 32&times;32
+//! * `icons.2` – 64&times;64
 
 use bevy::asset::UntypedHandle;
 use bevy::prelude::*;
@@ -26,30 +32,48 @@ use bevy_asset_loader::prelude::AssetCollection;
 use std::collections::HashMap;
 
 #[derive(Resource)]
-pub struct IconAssets(pub HashMap<String, Handle<Image>>);
+pub struct IconAssets(
+    /// 16x16 icons
+    pub HashMap<String, Handle<Image>>,
+    /// 32x32 icons
+    pub HashMap<String, Handle<Image>>,
+    /// 64x64 icons
+    pub HashMap<String, Handle<Image>>,
+);
+
+fn load_folder(asset_server: &AssetServer, folder: &str) -> HashMap<String, Handle<Image>> {
+    let mut map = HashMap::new();
+    if let Ok(handles) = asset_server.load_folder(folder) {
+        for handle in handles {
+            if let Some(path) = asset_server.get_handle_path(&handle) {
+                if let Some(stem) = path.path().file_stem().and_then(|s| s.to_str()) {
+                    map.insert(stem.to_string(), handle.clone().typed());
+                }
+            }
+        }
+    }
+    map
+}
 
 impl AssetCollection for IconAssets {
     fn create(world: &mut World) -> Self {
         let asset_server = world
             .get_resource::<AssetServer>()
             .expect("AssetServer missing");
-        let mut map = HashMap::new();
-        if let Ok(handles) = asset_server.load_folder("icons") {
-            for handle in handles {
-                if let Some(path) = asset_server.get_handle_path(&handle) {
-                    if let Some(stem) = path.path().file_stem().and_then(|s| s.to_str()) {
-                        map.insert(stem.to_string(), handle.clone().typed());
-                    }
-                }
-            }
-        }
-        IconAssets(map)
+        let map16 = load_folder(&asset_server, "16x16");
+        let map32 = load_folder(&asset_server, "32x32");
+        let map64 = load_folder(&asset_server, "64x64");
+        IconAssets(map16, map32, map64)
     }
 
     fn load(world: &mut World) -> Vec<UntypedHandle> {
         let asset_server = world
             .get_resource::<AssetServer>()
             .expect("AssetServer missing");
-        asset_server.load_folder("icons").unwrap_or_default()
+        let mut all = Vec::new();
+        all.extend(asset_server.load_folder("16x16").unwrap_or_default());
+        all.extend(asset_server.load_folder("32x32").unwrap_or_default());
+        all.extend(asset_server.load_folder("64x64").unwrap_or_default());
+        all
     }
 }

--- a/src/assets/icons/mod.rs
+++ b/src/assets/icons/mod.rs
@@ -1,6 +1,7 @@
 //! Helper module for icon assets.
 //!
-//! All icon textures live in the `assets/icons` directory and are loaded into
+//! All icon textures live in the `assets/16x16`, `assets/32x32` and
+//! `assets/64x64` directories and are loaded into
 //! [`IconAssets`](crate::assets::IconAssets) at startup. Builders expecting
 //! icons take a reference to this resource so handles can be fetched by name.
 

--- a/src/assets/mod.rs
+++ b/src/assets/mod.rs
@@ -1,7 +1,8 @@
 //! Asset collections used by Forge UI.
 //!
 //! The [`ForgeUiPlugin`](crate::plugin::ForgeUiPlugin) loads both fonts and
-//! icons at startup using `bevy_asset_loader`. Icons can then be accessed via
+//! icons at startup using `bevy_asset_loader`. Icons are stored in the
+//! `assets/16x16`, `assets/32x32` and `assets/64x64` folders and can then be accessed via
 //! [`IconAssets`], e.g. `icons.0.get("check")`.
 //!
 //! ```rust


### PR DESCRIPTION
## Summary
- load 16x16, 32x32 and 64x64 icon folders
- document the new icon asset structure

## Testing
- `cargo check` *(fails: system library `alsa` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684832e27a44832e8c3bafd3f31e67a3