### PR TITLE
Add accordion showcase and update checklist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,8 +73,8 @@ Identifiziere die erste unvollständige Komponente in der Liste und beginne mit 
     - `https://github.com/radix-ui/themes/tree/main/packages/radix-ui-themes/src/components/badge.css`
     - `https://github.com/radix-ui/themes/tree/main/packages/radix-ui-themes/src/components/badge.props.tsx`
     - `https://github.com/radix-ui/themes/tree/main/packages/radix-ui-themes/src/components/badge.tsx`
-- [ ] Komponente erstellt
-- [ ] Showcase erstellt
+- [x] Komponente erstellt
+- [x] Showcase erstellt
 - [ ]
 
 ### Button
@@ -87,8 +87,8 @@ Identifiziere die erste unvollständige Komponente in der Liste und beginne mit 
     - `https://github.com/radix-ui/themes/tree/main/packages/radix-ui-themes/src/components/button.css`
     - `https://github.com/radix-ui/themes/tree/main/packages/radix-ui-themes/src/components/button.props.tsx`
     - `https://github.com/radix-ui/themes/tree/main/packages/radix-ui-themes/src/components/button.tsx`
-- [ ] Komponente erstellt
-- [ ] Showcase erstellt
+- [x] Komponente erstellt
+- [x] Showcase erstellt
 
 ### Checkbox
 - Source:
@@ -100,8 +100,8 @@ Identifiziere die erste unvollständige Komponente in der Liste und beginne mit 
     - `https://github.com/radix-ui/themes/tree/main/packages/radix-ui-themes/src/components/checkbox.css`
     - `https://github.com/radix-ui/themes/tree/main/packages/radix-ui-themes/src/components/checkbox.props.tsx`
     - `https://github.com/radix-ui/themes/tree/main/packages/radix-ui-themes/src/components/checkbox.tsx`
-- [ ] Komponente erstellt
-- [ ] Showcase erstellt
+- [x] Komponente erstellt
+- [x] Showcase erstellt
 
 ### Checkbox Cards
 - Source:
@@ -206,7 +206,7 @@ Identifiziere die erste unvollständige Komponente in der Liste und beginne mit 
 - Source:
   - Primitives: `https://github.com/radix-ui/primitives/tree/main/packages/react/accordion/src`
 - [x] Komponente erstellt
-- [ ] Showcase erstellt
+- [x] Showcase erstellt
 
 ### Alert Dialog
 - Source:

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,8 +1,8 @@
 pub use crate::assets::*;
 pub use crate::components::helper::*;
 pub use crate::components::{
-    badge::*, button::*, checkbox::*, dialog::*, label::*, portal::*, radio::*, radio_group::*,
-    switch::*, toggle::*, toggle_group::*,
+    badge::*, button::*, accordion::*, checkbox::*, dialog::*, label::*, portal::*, radio::*,
+    radio_group::*, switch::*, toggle::*, toggle_group::*,
 };
 pub use crate::layout::*;
 pub use crate::plugin::{ForgeUiPlugin, UiState};

--- a/src/showcase/components/accordion.rs
+++ b/src/showcase/components/accordion.rs
@@ -1,0 +1,57 @@
+use super::super::helpers::*;
+use crate::prelude::*;
+use bevy::prelude::*;
+
+pub fn show_accordion_variants(
+    parent: &mut ChildSpawnerCommands,
+    theme: &UiTheme,
+    font: &Handle<Font>,
+) {
+    let mut section = create_variant_section(parent, "Accordions", theme, font);
+
+    section.with_children(|vc| {
+        AccordionBuilder::new("Closed")
+            .content(|p, t, f| {
+                p.spawn((
+                    Text::new("Content"),
+                    TextFont {
+                        font: f.clone(),
+                        font_size: t.font.size.base,
+                        ..default()
+                    },
+                    TextColor(t.color.slate.step12),
+                ));
+            })
+            .spawn(vc, theme, font);
+
+        AccordionBuilder::new("Open")
+            .open(true)
+            .content(|p, t, f| {
+                p.spawn((
+                    Text::new("Content"),
+                    TextFont {
+                        font: f.clone(),
+                        font_size: t.font.size.base,
+                        ..default()
+                    },
+                    TextColor(t.color.slate.step12),
+                ));
+            })
+            .spawn(vc, theme, font);
+
+        AccordionBuilder::new("Disabled")
+            .disabled(true)
+            .content(|p, t, f| {
+                p.spawn((
+                    Text::new("Content"),
+                    TextFont {
+                        font: f.clone(),
+                        font_size: t.font.size.base,
+                        ..default()
+                    },
+                    TextColor(t.color.slate.step12),
+                ));
+            })
+            .spawn(vc, theme, font);
+    });
+}

--- a/src/showcase/components/mod.rs
+++ b/src/showcase/components/mod.rs
@@ -1,5 +1,6 @@
 mod badge;
 mod button;
+mod accordion;
 mod checkbox;
 mod dialog;
 mod label;
@@ -8,6 +9,7 @@ mod switch;
 mod toggle;
 pub use badge::*;
 pub use button::*;
+pub use accordion::*;
 pub use checkbox::*;
 pub use dialog::*;
 pub use label::*;

--- a/src/showcase/helpers.rs
+++ b/src/showcase/helpers.rs
@@ -22,6 +22,7 @@ pub enum ShowcaseAction {
 #[derive(Clone, Debug, PartialEq, Eq, Component)]
 pub enum ShowcaseElement {
     Button,
+    Accordion,
     Checkbox,
     RadioGroup,
     Toggle,

--- a/src/showcase/sidebar_layout.rs
+++ b/src/showcase/sidebar_layout.rs
@@ -89,6 +89,12 @@ pub fn build_sidebar(
         )
         .add_entity(
             ButtonBuilder::new_for_action()
+                .text("Accordion")
+                .action(ShowcaseAction::ShowElement(ShowcaseElement::Accordion))
+                .spawn(parent, theme, font),
+        )
+        .add_entity(
+            ButtonBuilder::new_for_action()
                 .text("Switch")
                 .action(ShowcaseAction::ShowElement(ShowcaseElement::Switch))
                 .spawn(parent, theme, font),
@@ -191,6 +197,9 @@ pub fn handle_select_element(
                             check_icon_handle,
                             cross_icon_handle,
                         ),
+                        ShowcaseElement::Accordion => {
+                            show_accordion_variants(vc, &theme, &font.default);
+                        }
                         ShowcaseElement::Badge => {
                             show_badge_variants(vc, &theme, &font.default, &icons)
                         }


### PR DESCRIPTION
## Summary
- mark Badge, Button and Checkbox as done in Agents checklist
- add Accordion to prelude and showcase helpers
- create `show_accordion_variants` showcase
- wire Accordion showcase into sidebar layout

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68487d3e57c8832e96dcd844849952d5