### PR TITLE
Add disabled overlay to accordion

### DIFF
--- a/src/components/accordion/builder.rs
+++ b/src/components/accordion/builder.rs
@@ -138,6 +138,27 @@ impl AccordionBuilder {
             }
         });
 
+        if self.disabled {
+            spawn_disabled_overlay(&mut cmd, theme);
+        }
+
         cmd
     }
+}
+
+fn spawn_disabled_overlay<'w>(cmd: &mut EntityCommands<'w>, theme: &UiTheme) {
+    cmd.with_children(|parent| {
+        parent.spawn((
+            Node {
+                position_type: PositionType::Absolute,
+                left: Val::Px(0.0),
+                top: Val::Px(0.0),
+                width: Val::Percent(100.0),
+                height: Val::Percent(100.0),
+                ..default()
+            },
+            BackgroundColor(theme.color.black.step08),
+            FocusPolicy::Block,
+        ));
+    });
 }


### PR DESCRIPTION
## Summary
- overlay disabled accordions with a translucent layer

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68496e67f4ac832eb9aabbf7f821fd48