### PR TITLE
Switch UiRoot to bundle-style API

### DIFF
--- a/src/layout/builder/root.rs
+++ b/src/layout/builder/root.rs
@@ -6,28 +6,29 @@ use bevy::prelude::*; // Optional, falls Theme Styling beeinflusst
 pub struct UiRoot;
 
 impl UiRoot {
-    pub fn spawn(commands: &mut Commands, theme: &UiTheme) -> Entity {
-        commands
-            .spawn((
-                UiRoot,
-                // Style und Hintergrundfarbe bleiben wie gehabt
-                Node {
-                    position_type: PositionType::Absolute,
-                    top: Val::Px(0.0),
-                    left: Val::Px(0.0),
-                    width: Val::Percent(100.0),
-                    height: Val::Percent(100.0),
-                    display: Display::Flex,
-                    flex_direction: FlexDirection::Column,
-                    justify_content: JustifyContent::Center,
-                    align_items: AlignItems::Center,
-                    padding: UiRect::all(Val::Px(theme.layout.padding.base)),
-                    ..default()
-                },
-                BackgroundColor(theme.color.gray.step01),
-                // ─── Hier kommen die fehlenden UI-Bundles ───
-                Visibility::Visible,
-            ))
-            .id()
+    /// Returns the bundle of components used for the root UI node. This mirrors
+    /// the approach in `widget.rs` where a helper function returns `impl Bundle`
+    /// instead of spawning the entity directly.
+    pub fn bundle(theme: &UiTheme) -> impl Bundle {
+        (
+            UiRoot,
+            // Style und Hintergrundfarbe bleiben wie gehabt
+            Node {
+                position_type: PositionType::Absolute,
+                top: Val::Px(0.0),
+                left: Val::Px(0.0),
+                width: Val::Percent(100.0),
+                height: Val::Percent(100.0),
+                display: Display::Flex,
+                flex_direction: FlexDirection::Column,
+                justify_content: JustifyContent::Center,
+                align_items: AlignItems::Center,
+                padding: UiRect::all(Val::Px(theme.layout.padding.base)),
+                ..default()
+            },
+            BackgroundColor(theme.color.gray.step01),
+            // ─── Hier kommen die fehlenden UI-Bundles ───
+            Visibility::Visible,
+        )
     }
 }

--- a/src/showcase/sidebar_layout.rs
+++ b/src/showcase/sidebar_layout.rs
@@ -8,7 +8,7 @@ use bevy::prelude::*;
 
 /// Erzeugt beim Start die Root-Nodes: Sidebar (links) + Content-Container (rechts).
 pub fn setup_ui(mut commands: Commands, theme: Res<UiTheme>, font: Res<FontAssets>) {
-    let root = UiRoot::spawn(&mut commands, &theme);
+    let root = commands.spawn(UiRoot::bundle(&theme)).id();
     commands
         .entity(root)
         .insert((ShowcaseMarker, Name::new("Showcase UI")));


### PR DESCRIPTION
## Summary
- refactor `UiRoot` so it provides `bundle()` that returns `impl Bundle`
- use the new bundle-style API in the sidebar showcase

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_685139976da4832e9b2d62c3f5376e01